### PR TITLE
Reset Record tab after saving new recording

### DIFF
--- a/app/(tabs)/record/review.js
+++ b/app/(tabs)/record/review.js
@@ -88,6 +88,11 @@ const RecordingReview = () => {
       await sound.unloadAsync();
       setSound(() => null);
 
+      // TODO: better way to reset the Review screen
+      // so that navigating back to Record from Riffs
+      // shows the Setup screen
+      router.replace('/record/setup');
+
       // Show new sound in riffs screen
       router.push('/riffs');
     } catch (error) {


### PR DESCRIPTION
After a new recording is saved by the user, the router redirects the screen from `/record/review` to `/riffs`.

The problem is that if you navigate to the `Record` tab, the `review` screen is still showing, instead of the `setup` screen.

Until a better solution is implemented, this PR redirects the router to `/record/setup` and then it continues the redirect to `/riffs`